### PR TITLE
Fix code sample modelEvents in View doc

### DIFF
--- a/docs/marionette.view.md
+++ b/docs/marionette.view.md
@@ -614,7 +614,7 @@ var MyView = Mn.View.extend({
     'change:attribute': 'actOnChange'
   },
 
-  actOnChange: function(value, model) {
+  actOnChange: function(model, value) {
     console.log('New value: ' + value);
   }
 });


### PR DESCRIPTION
In the modelEvents code example, the callback function arguments are in the wrong order.
The model is passed first and then the value.

